### PR TITLE
Publish build scans to develocity.apache.org

### DIFF
--- a/.github/workflows/android-reusable-test.yaml
+++ b/.github/workflows/android-reusable-test.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0bdd871935719febd78681f197cd39af5b6e16a6   # 4.2.2
         with:
-          develocity-access-key: ${{ secrets.GE_ACCESS_KEY }}
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
           develocity-injection-enabled: true
           develocity-url: https://develocity.apache.org
           develocity-plugin-version: 3.18.2

--- a/.github/workflows/android-reusable-test.yaml
+++ b/.github/workflows/android-reusable-test.yaml
@@ -62,7 +62,7 @@ jobs:
           develocity-access-key: ${{ secrets.GE_ACCESS_KEY }}
           develocity-injection-enabled: true
           develocity-url: https://develocity.apache.org
-          develocity-plugin-version: 3.18.1
+          develocity-plugin-version: 3.18.2
 
 
       - name: Enable KVM

--- a/.github/workflows/android-reusable-test.yaml
+++ b/.github/workflows/android-reusable-test.yaml
@@ -61,7 +61,7 @@ jobs:
         with:
           develocity-access-key: ${{ secrets.GE_ACCESS_KEY }}
           develocity-injection-enabled: true
-          develocity-url: https://ge.apache.org
+          develocity-url: https://develocity.apache.org
           develocity-plugin-version: 3.18.1
 
 


### PR DESCRIPTION
This PR migrates the Log4j project to publish Build Scans to the the new Develocity instance at develocity.apache.org.
