### PR TITLE
Remove daily samples build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,8 +30,6 @@ on:
       - "**.adoc"
       - "**.md"
       - "**.txt"
-  schedule:
-    - cron: "29 17 * * *"
 
 permissions: read-all
 


### PR DESCRIPTION
The daily build of samples is no longer necessary, since a build occurs:

- When a change to the `main` branch is pushed.
- When a new snapshot or release is built in `logging-log4j2`.
- When a PR in this repo is evaluated.

This should account for all the possible factors that can influence the result of a build.