### PR TITLE
Pass arguments to Gradle via environment variables

### DIFF
--- a/.github/workflows/gradle-reusable-test.yaml
+++ b/.github/workflows/gradle-reusable-test.yaml
@@ -71,8 +71,6 @@ jobs:
           LOG4J_REPOSITORY_URL: ${{ inputs.log4j-repository-url }}
         run: |
           ./gradlew \
-          -Plog4j.version=$LOG4J_VERSION \
-          -Plog4j.repository.url=$LOG4J_REPOSITORY_URL \
           :log4j-samples-gradle-metadata:check
 
       - name: Enable KVM
@@ -129,8 +127,6 @@ jobs:
           LOG4J_REPOSITORY_URL: ${{ inputs.log4j-repository-url }}
         run: |
           ./gradlew \
-          -Plog4j.version=$LOG4J_VERSION \
-          -Plog4j.repository.url=$LOG4J_REPOSITORY_URL \
           :app:build :app:connectedCheck
 
       - name: Remove AVD Device

--- a/log4j-samples-android/app/build.gradle
+++ b/log4j-samples-android/app/build.gradle
@@ -49,7 +49,7 @@ android {
     }
 }
 
-def log4jVersion = providers.gradleProperty("log4j.version").get()
+def log4jVersion = providers.environmentVariable("LOG4J_VERSION").getOrElse("2.+")
 
 dependencies {
 

--- a/log4j-samples-gradle-metadata/build.gradle
+++ b/log4j-samples-gradle-metadata/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id("application")
 }
 
-def log4jVersion = providers.gradleProperty("log4j.version").getOrElse("2.+")
+def log4jVersion = providers.environmentVariable("LOG4J_VERSION").getOrElse("2.+")
 
 application {
     mainModule = "org.example.log4j.metadata"

--- a/settings.gradle
+++ b/settings.gradle
@@ -36,7 +36,7 @@ dependencyResolutionManagement {
         // Points to the correct Apache staging repository
         //
         // See gradle.properties
-        var repositoryUrl = providers.gradleProperty("log4j.repository.url")
+        var repositoryUrl = providers.environmentVariable('LOG4J_REPOSITORY_URL').get()
         if (repositoryUrl != null && !repositoryUrl.toString().isEmpty()) {
             maven {
                 name = 'Apache Repository'


### PR DESCRIPTION
This PR passes arguments to the Gradle builds via the `LOG4J_VERSION` and `LOG4J_REPOSITORY_URL` environment variables.

This simplifies the build, since no command line parameters need to be used.