### PR TITLE
Upgrade defaults to `2.25.0` and `2.26.0-SNAPSHOT`

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -39,6 +39,7 @@ updates:
       - maven-central
     ignore:
       - dependency-name: "org.apache.logging.log4j:*"
+        versions: ["[3,)"]
 
   - package-ecosystem: gradle
     directories:
@@ -53,6 +54,7 @@ updates:
       - maven-central
     ignore:
       - dependency-name: "org.apache.logging.log4j:*"
+        versions: ["[3,)"]
 
   - package-ecosystem: github-actions
     directory: "/"

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -24,7 +24,7 @@ on:
         description: Version of Log4j Core
         type: string
         # Should point to the current 2.x snapshot version
-        default: 2.25.0-SNAPSHOT
+        default: 2.26.0-SNAPSHOT
       log4j-repository-url:
         description: Staging Maven repository. Should be empty for snapshots.
         type: string
@@ -46,9 +46,6 @@ on:
         description: The branch, tag or SHA of `logging-log4j-samples` to checkout
         type: string
         default: 'refs/heads/main'
-
-env:
-  MAVEN_ARGS: ${{ inputs.log4j-version }}
 
 permissions: read-all
 

--- a/log4j-samples-graalvm/pom.xml
+++ b/log4j-samples-graalvm/pom.xml
@@ -36,7 +36,7 @@
       ~ Set to latest stable 2.x release for users.
       ~ Our workflows override this.
       -->
-    <log4j.version>2.24.3</log4j.version>
+    <log4j.version>2.25.0</log4j.version>
 
     <!-- Some samples require JDK 9+ -->
     <minimalJavaBuildVersion>17</minimalJavaBuildVersion>

--- a/log4j-samples-gradle-metadata/build.gradle
+++ b/log4j-samples-gradle-metadata/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id("application")
 }
 
-def log4jVersion = providers.environmentVariable("LOG4J_VERSION").getOrElse("2.+")
+def log4jVersion = providers.environmentVariable("LOG4J_VERSION").getOrElse("2.25.0")
 
 application {
     mainModule = "org.example.log4j.metadata"

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
       ~ Set to latest stable 2.x release for users.
       ~ Our workflows override this.
       -->
-    <log4j.version>2.24.3</log4j.version>
+    <log4j.version>2.25.0</log4j.version>
 
     <!-- Some samples require JDK 17+ -->
     <minimalJavaBuildVersion>17</minimalJavaBuildVersion>


### PR DESCRIPTION
This PR updates the default Log4j versions used in the project:

* **Examples now default to `2.25.0`**, the latest stable release. This ensures that users trying out the samples work with a well-tested, production-ready version.
* **CI workflows now use `2.26.0-SNAPSHOT`**, allowing us to verify fixes that have already been applied in snapshot builds. This helps catch regressions and confirm that known issues in `2.25.0` have been addressed.