### PR TITLE
Gradle: Reproducer for apache/logging-log4j2#3779

### DIFF
--- a/log4j-samples-gradle-metadata/build.gradle
+++ b/log4j-samples-gradle-metadata/build.gradle
@@ -16,6 +16,7 @@
  */
 plugins {
     id("application")
+    id "io.spring.dependency-management" version "1.1.7"
 }
 
 def log4jVersion = providers.environmentVariable("LOG4J_VERSION").getOrElse("2.25.0")

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,6 +21,42 @@ pluginManagement {
         mavenCentral()
     }
 }
+
+/*
+ * Fail the build if any WARN/ERROR log events occur.
+ * Some projects forbid *any* build-time logging at these levels;
+ * this ensures Log4j upgrades don't get blocked by harmless noise.
+ *
+ * See: https://github.com/apache/logging-log4j2/issues/3779
+ */
+import org.gradle.internal.logging.events.LogEvent
+import org.gradle.internal.logging.LoggingManagerInternal
+def events = []
+def listener = { e ->
+    if (e instanceof LogEvent && e.logLevel.ordinal() >= LogLevel.WARN.ordinal()) {
+        events << e
+    }
+}
+
+gradle.settingsEvaluated {
+    def loggingManager = gradle.services.get(LoggingManagerInternal)
+    loggingManager.addOutputEventListener(listener)
+    /*
+     * Note: This relies on Gradle’s internal logging APIs.
+     * It may break in Gradle 9.x or later, but that’s expected —
+     * using internal hooks is unsupported until Gradle provides a stable alternative.
+     */
+    gradle.buildFinished {
+        loggingManager.removeOutputEventListener(listener)
+        if (!events.isEmpty()) {
+            println "\n* Build failed due to ${events.size()} WARN/ERROR log event(s):"
+            events.each { println "[${it.logLevel}] ${it.message}" }
+            throw new GradleException("Build aborted: disallowed WARN/ERROR log events detected.")
+        }
+    }
+}
+
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
This is a PR that addresses https://github.com/apache/logging-log4j-samples/pull/350#issuecomment-3069913098.

Now, this command

```
export LOG4J_VERSION=2.25.1; ./gradlew :log4j-samples-gradle-metadata:build
```

leads to

```
Errors occurred while building effective model from /Users/me/.gradle/caches/modules-2/files-2.1/org.apache.logging.log4j/log4j-api/2.25.1/bac75b77765d4eb74e4122d34000d7892c6605fa/log4j-api-2.25.1.pom:
        'dependencies.dependency.version' for com.google.errorprone:error_prone_annotations:jar must be a valid version but is '${error-prone.version}'. in org.apache.logging.log4j:log4j-api:2.25.1

BUILD SUCCESSFUL in 648ms
```

(Note that the build is successful but the error is still reported. So in a way, the error seems non-blocking but honestly I would not rely on it.)

cc @ppkarwasz