### PR TITLE
feat: centralize default Log4j version in `gradle.properties`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ android.useAndroidX = true
 # Version of Log4j Core
 #
 # Default: last stable 2.x release
-log4j.version = 2.24.3
+log4jVersion = 2.25.1
 
 ##
 # Staging Maven Repository

--- a/log4j-samples-android/app/build.gradle
+++ b/log4j-samples-android/app/build.gradle
@@ -49,8 +49,6 @@ android {
     }
 }
 
-def log4jVersion = providers.environmentVariable("LOG4J_VERSION").getOrElse("2.+")
-
 dependencies {
 
     implementation 'androidx.appcompat:appcompat:1.7.1'
@@ -63,9 +61,9 @@ dependencies {
     androidTestImplementation 'org.assertj:assertj-core:3.27.4'
 
     // Log4j
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: log4jVersion
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: log4jVersion
-    androidTestImplementation(group: 'org.apache.logging.log4j', name: 'log4j-core-test', version: log4jVersion) {
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: project.ext.log4jVersion
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: project.ext.log4jVersion
+    androidTestImplementation(group: 'org.apache.logging.log4j', name: 'log4j-core-test', version: project.ext.log4jVersion) {
         exclude group: 'com.google.code.java-allocation-instrumenter'
         exclude group: 'org.apache.logging.log4j', module: 'log4j-api-test'
         exclude group: 'org.hamcrest'

--- a/log4j-samples-gradle-metadata/build.gradle
+++ b/log4j-samples-gradle-metadata/build.gradle
@@ -18,15 +18,13 @@ plugins {
     id("application")
 }
 
-def log4jVersion = providers.environmentVariable("LOG4J_VERSION").getOrElse("2.25.0")
-
 application {
     mainModule = "org.example.log4j.metadata"
     mainClass = "org.example.App" // see: src/main/java/org/example/App.java
 }
 
 dependencies {
-    implementation("org.apache.logging.log4j:log4j-api:$log4jVersion")
+    implementation("org.apache.logging.log4j:log4j-api:${project.ext.log4jVersion}")
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/settings.gradle
+++ b/settings.gradle
@@ -44,6 +44,12 @@ dependencyResolutionManagement {
     }
 }
 rootProject.name = 'logging-log4j-samples'
+def log4jVersion = providers.environmentVariable("LOG4J_VERSION")
+        .orElse(providers.gradleProperty("log4jVersion"))
+        .get()
+gradle.beforeProject { Project it ->
+    it.ext.log4jVersion = log4jVersion
+}
 
 // Android example
 include ':app'


### PR DESCRIPTION
The default Log4j version is now defined in `gradle.properties` instead of being hard-coded in build logic. This makes it easier to update or override the version consistently across the build.