### PR TITLE
Remove `spotbugs-annotations` checks

### DIFF
--- a/log4j-samples-gradle-metadata/build.gradle
+++ b/log4j-samples-gradle-metadata/build.gradle
@@ -45,7 +45,6 @@ def expectedCompileClasspath = [
     "biz.aQute.bnd.annotation",
     "error_prone_annotations",
     "jspecify",
-    "jsr305",
     "log4j-api",
     "org.osgi.annotation.bundle",
     "org.osgi.annotation.versioning",

--- a/log4j-samples-gradle-metadata/build.gradle
+++ b/log4j-samples-gradle-metadata/build.gradle
@@ -50,8 +50,7 @@ def expectedCompileClasspath = [
     "org.osgi.annotation.bundle",
     "org.osgi.annotation.versioning",
     "org.osgi.resource",
-    "org.osgi.service.serviceloader",
-    "spotbugs-annotations"
+    "org.osgi.service.serviceloader"
 ]
 
 tasks.register("assertRuntimeClasspath") {


### PR DESCRIPTION
apache/logging-log4j2#3985 removed `spotbugs-annotations` from Log4j – remove related checks. See [this CI run] demonstrating the `log4j-samples-gradle-metadata` failure.

[this CI run]: https://github.com/apache/logging-log4j2/actions/runs/19683105913