### PR TITLE
Add integration test for log4j-samples-jlink module

### DIFF
--- a/log4j-samples-jlink/pom.xml
+++ b/log4j-samples-jlink/pom.xml
@@ -15,8 +15,10 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://www.w3.org/xsd/maven-4.0.0.xsd">
+
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>org.apache.logging.log4j.samples</groupId>
     <artifactId>log4j-samples</artifactId>
@@ -30,6 +32,12 @@
   <properties>
     <!-- Plugin version -->
     <maven-jlink-plugin.version>3.2.0</maven-jlink-plugin.version>
+
+    <!-- OS-specific launcher suffix -->
+    <launcher.suffix />
+
+    <!-- Optional readability improvement -->
+    <jlink.launcher.path>${project.build.directory}/maven-jlink/default/bin/${project.artifactId}${launcher.suffix}</jlink.launcher.path>
   </properties>
 
   <dependencies>
@@ -39,7 +47,6 @@
       <artifactId>log4j-api</artifactId>
     </dependency>
 
-    <!-- Runtime dependencies -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
@@ -51,7 +58,7 @@
       <scope>runtime</scope>
     </dependency>
 
-    <!-- TEST DEPENDENCIES -->
+    <!-- TEST -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -59,8 +66,10 @@
     </dependency>
 
   </dependencies>
+
   <build>
     <plugins>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
@@ -81,6 +90,7 @@
         </executions>
       </plugin>
 
+      <!-- ✅ FIXED HERE -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
@@ -93,7 +103,7 @@
             </goals>
             <phase>integration-test</phase>
             <configuration>
-              <executable>${project.build.directory}/maven-jlink/default/bin/${project.artifactId}</executable>
+              <executable>${jlink.launcher.path}</executable>
               <outputFile>${project.build.directory}/logs/out.log</outputFile>
             </configuration>
           </execution>
@@ -128,6 +138,23 @@
           <launcher>log4j-samples-jlink=org.apache.logging.log4j.samples.jlink/org.apache.logging.log4j.samples.jlink.Main</launcher>
         </configuration>
       </plugin>
+
     </plugins>
   </build>
+
+  <!-- ✅ Windows profile -->
+  <profiles>
+    <profile>
+      <id>windows</id>
+      <activation>
+        <os>
+          <family>Windows</family>
+        </os>
+      </activation>
+      <properties>
+        <launcher.suffix>.exe</launcher.suffix>
+      </properties>
+    </profile>
+  </profiles>
+
 </project>

--- a/log4j-samples-jlink/pom.xml
+++ b/log4j-samples-jlink/pom.xml
@@ -15,7 +15,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://www.w3.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 

--- a/log4j-samples-jlink/pom.xml
+++ b/log4j-samples-jlink/pom.xml
@@ -43,7 +43,6 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -52,9 +51,81 @@
       <scope>runtime</scope>
     </dependency>
 
+    <!-- TEST DEPENDENCIES -->
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>prepare-integration-test-logs</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>pre-integration-test</phase>
+            <configuration>
+              <target>
+                <mkdir dir="${project.build.directory}/logs" />
+                <delete file="${project.build.directory}/logs/out.log" />
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>${exec-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>run-custom-jlink-launcher</id>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <phase>integration-test</phase>
+            <configuration>
+              <executable>${project.build.directory}/maven-jlink/default/bin/${project.artifactId}</executable>
+              <outputFile>${project.build.directory}/logs/out.log</outputFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>integration-test</id>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <includes>
+                <include>**/StandardIT.class</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jlink-plugin</artifactId>

--- a/log4j-samples-jlink/pom.xml
+++ b/log4j-samples-jlink/pom.xml
@@ -52,16 +52,9 @@
     </dependency>
 
     <!-- TEST DEPENDENCIES -->
-
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/log4j-samples-jlink/pom.xml
+++ b/log4j-samples-jlink/pom.xml
@@ -34,10 +34,10 @@
     <maven-jlink-plugin.version>3.2.0</maven-jlink-plugin.version>
 
     <!-- OS-specific launcher suffix -->
-    <launcher.suffix />
+    <jlink.launcher.suffix />
 
     <!-- Optional readability improvement -->
-    <jlink.launcher.path>${project.build.directory}/maven-jlink/default/bin/${project.artifactId}${launcher.suffix}</jlink.launcher.path>
+    <jlink.launcher.path>${project.build.directory}/maven-jlink/default/bin/${project.artifactId}${jlink.launcher.suffix}</jlink.launcher.path>
   </properties>
 
   <dependencies>
@@ -60,8 +60,8 @@
 
     <!-- TEST -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -90,7 +90,6 @@
         </executions>
       </plugin>
 
-      <!-- ✅ FIXED HERE -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
@@ -142,7 +141,6 @@
     </plugins>
   </build>
 
-  <!-- ✅ Windows profile -->
   <profiles>
     <profile>
       <id>windows</id>
@@ -152,7 +150,7 @@
         </os>
       </activation>
       <properties>
-        <launcher.suffix>.exe</launcher.suffix>
+        <jlink.launcher.suffix>.exe</jlink.launcher.suffix>
       </properties>
     </profile>
   </profiles>

--- a/log4j-samples-jlink/src/test/java/org/apache/logging/log4j/samples/jlink/StandardIT.java
+++ b/log4j-samples-jlink/src/test/java/org/apache/logging/log4j/samples/jlink/StandardIT.java
@@ -22,8 +22,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class StandardIT {
 
@@ -32,15 +32,15 @@ public class StandardIT {
         final Path basePath = Paths.get(System.getProperty("basedir"), "target", "logs");
         final Path logFile = basePath.resolve("out.log");
 
-        Assert.assertTrue("Log file does not exist", Files.exists(logFile));
-        Assert.assertTrue("Log file is empty", Files.size(logFile) > 0);
+        Assertions.assertTrue(Files.exists(logFile), "Log file does not exist");
+        Assertions.assertTrue(Files.size(logFile) > 0, "Log file is empty");
 
         final List<String> lines = Files.readAllLines(logFile, StandardCharsets.UTF_8);
 
-        Assert.assertEquals(2, lines.size());
-        Assert.assertTrue(lines.get(0)
+        Assertions.assertEquals(2, lines.size());
+        Assertions.assertTrue(lines.get(0)
                 .matches("XML: .* INFO\\s+\\[main] o\\.a\\.l\\.l\\.s\\.j\\.Main Starting Log4j JLink Sample\\.\\.\\."));
-        Assert.assertTrue(
+        Assertions.assertTrue(
                 lines.get(1)
                         .matches(
                                 "XML: .* WARN\\s+\\[main] o\\.a\\.l\\.l\\.s\\.j\\.Main Please add your name as command line parameter\\."));

--- a/log4j-samples-jlink/src/test/java/org/apache/logging/log4j/samples/jlink/StandardIT.java
+++ b/log4j-samples-jlink/src/test/java/org/apache/logging/log4j/samples/jlink/StandardIT.java
@@ -16,32 +16,33 @@
  */
 package org.apache.logging.log4j.samples.jlink;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import org.junit.jupiter.api.Test;
+import org.junit.Assert;
+import org.junit.Test;
 
-class StandardIT {
+public class StandardIT {
 
     @Test
-    void verifyStdOut() throws IOException {
+    public void verifyStdOut() throws IOException {
         final Path basePath = Paths.get(System.getProperty("basedir"), "target", "logs");
         final Path logFile = basePath.resolve("out.log");
 
-        assertThat(logFile).exists().isNotEmptyFile();
+        Assert.assertTrue("Log file does not exist", Files.exists(logFile));
+        Assert.assertTrue("Log file is empty", Files.size(logFile) > 0);
 
         final List<String> lines = Files.readAllLines(logFile, StandardCharsets.UTF_8);
 
-        assertThat(lines).hasSize(2);
-        assertThat(lines.get(0))
-                .matches("XML: .* INFO\\s+\\[main] o\\.a\\.l\\.l\\.s\\.j\\.Main Starting Log4j JLink Sample\\.\\.\\.");
-        assertThat(lines.get(1))
-                .matches(
-                        "XML: .* WARN\\s+\\[main] o\\.a\\.l\\.l\\.s\\.j\\.Main Please add your name as command line parameter\\.");
+        Assert.assertEquals(2, lines.size());
+        Assert.assertTrue(lines.get(0)
+                .matches("XML: .* INFO\\s+\\[main] o\\.a\\.l\\.l\\.s\\.j\\.Main Starting Log4j JLink Sample\\.\\.\\."));
+        Assert.assertTrue(
+                lines.get(1)
+                        .matches(
+                                "XML: .* WARN\\s+\\[main] o\\.a\\.l\\.l\\.s\\.j\\.Main Please add your name as command line parameter\\."));
     }
 }

--- a/log4j-samples-jlink/src/test/java/org/apache/logging/log4j/samples/jlink/StandardIT.java
+++ b/log4j-samples-jlink/src/test/java/org/apache/logging/log4j/samples/jlink/StandardIT.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.samples.jlink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class StandardIT {
+
+    @Test
+    void verifyStdOut() throws IOException {
+        final Path basePath = Paths.get(System.getProperty("basedir"), "target", "logs");
+        final Path logFile = basePath.resolve("out.log");
+
+        assertThat(logFile).exists().isNotEmptyFile();
+
+        final List<String> lines = Files.readAllLines(logFile, StandardCharsets.UTF_8);
+
+        assertThat(lines).hasSize(2);
+        assertThat(lines.get(0))
+                .matches("XML: .* INFO\\s+\\[main] o\\.a\\.l\\.l\\.s\\.j\\.Main Starting Log4j JLink Sample\\.\\.\\.");
+        assertThat(lines.get(1))
+                .matches(
+                        "XML: .* WARN\\s+\\[main] o\\.a\\.l\\.l\\.s\\.j\\.Main Please add your name as command line parameter\\.");
+    }
+}


### PR DESCRIPTION
Issue #231 

This PR adds an integration test to the log4j-samples-jlink module, similar to the approach used in log4j-samples-graalvm. The new test verifies that the Main class functions correctly within the custom JLink environment, using a StandardIT integration test. This ensures the module’s runtime behavior is validated and consistent with other sample modules. No changes to production code; only test coverage improvements.