### PR TITLE
Fix jlink launcher execution failure on Windows CI

### DIFF
--- a/log4j-samples-jlink/pom.xml
+++ b/log4j-samples-jlink/pom.xml
@@ -16,9 +16,7 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
   <modelVersion>4.0.0</modelVersion>
-
   <parent>
     <groupId>org.apache.logging.log4j.samples</groupId>
     <artifactId>log4j-samples</artifactId>
@@ -30,104 +28,39 @@
   <name>Apache Log4j Samples: JLink custom JRE</name>
 
   <properties>
-    <!-- Plugin version -->
     <maven-jlink-plugin.version>3.2.0</maven-jlink-plugin.version>
-
-    <!-- OS-specific launcher suffix -->
-    <jlink.launcher.suffix />
-
-    <!-- Optional readability improvement -->
-    <jlink.launcher.path>${project.build.directory}/maven-jlink/default/bin/${project.artifactId}${jlink.launcher.suffix}</jlink.launcher.path>
+    <!-- Base path for the launcher created by jlink -->
+    <jlink.launcher.path>${project.build.directory}/maven-jlink/default/bin/log4j-samples-jlink</jlink.launcher.path>
+    <!-- Defaults for Unix/macOS -->
+    <exec.launcher.cmd>${jlink.launcher.path}</exec.launcher.cmd>
+    <exec.launcher.arg0 />
+    <exec.launcher.arg1 />
   </properties>
 
   <dependencies>
-
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
+      <scope>runtime</scope>
     </dependency>
-
     <dependency>
       <groupId>org.apache.logging.log4j.samples</groupId>
       <artifactId>log4j-samples-configuration</artifactId>
       <scope>runtime</scope>
     </dependency>
-
-    <!-- TEST -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
   <build>
     <plugins>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>prepare-integration-test-logs</id>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <phase>pre-integration-test</phase>
-            <configuration>
-              <target>
-                <mkdir dir="${project.build.directory}/logs" />
-                <delete file="${project.build.directory}/logs/out.log" />
-              </target>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>${exec-maven-plugin.version}</version>
-        <executions>
-          <execution>
-            <id>run-custom-jlink-launcher</id>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <phase>integration-test</phase>
-            <configuration>
-              <executable>${jlink.launcher.path}</executable>
-              <outputFile>${project.build.directory}/logs/out.log</outputFile>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>integration-test</id>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-            <configuration>
-              <includes>
-                <include>**/StandardIT.class</include>
-              </includes>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jlink-plugin</artifactId>
@@ -138,21 +71,44 @@
         </configuration>
       </plugin>
 
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>run-custom-jlink-launcher</id>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <phase>verify</phase>
+            <configuration combine.self="override">
+              <skip>${skipTests}</skip>
+              <executable>${exec.launcher.cmd}</executable>
+              <arguments>
+                <argument>${exec.launcher.arg0}</argument>
+                <argument>${exec.launcher.arg1}</argument>
+              </arguments>
+              <workingDirectory>${project.basedir}</workingDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
   <profiles>
     <profile>
-      <id>windows</id>
+      <id>windows-setup</id>
       <activation>
         <os>
-          <family>Windows</family>
+          <family>windows</family>
         </os>
       </activation>
       <properties>
-        <jlink.launcher.suffix>.exe</jlink.launcher.suffix>
+        <exec.launcher.cmd>cmd</exec.launcher.cmd>
+        <exec.launcher.arg0>/c</exec.launcher.arg0>
+        <exec.launcher.arg1>${jlink.launcher.path}.bat</exec.launcher.arg1>
       </properties>
     </profile>
   </profiles>
-
 </project>

--- a/log4j-samples-jlink/pom.xml
+++ b/log4j-samples-jlink/pom.xml
@@ -74,6 +74,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
+        <version>${exec-maven-plugin.version}</version>
         <executions>
           <execution>
             <id>run-custom-jlink-launcher</id>


### PR DESCRIPTION
Fixes #395 

Resolve 'CreateProcess error=2' on Windows by adding a profile to invoke the .bat launcher script via 'cmd /c'.

https://github.com/ramanathan1504/logging-log4j-samples/actions/runs/25513553770