### PR TITLE
Improve Dependabot group names and add update cooldown

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -31,8 +31,10 @@ updates:
       - "log4j-samples-graalvm"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
-      all:
+      maven-updates:
         patterns:
           - "*"
     registries:
@@ -46,8 +48,10 @@ updates:
       - "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
-      all:
+      gradle-updates:
         patterns:
           - "*"
     registries:
@@ -60,7 +64,9 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
-      all:
+      github-actions-updates:
         patterns:
           - "*"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -34,9 +34,10 @@ updates:
     cooldown:
       default-days: 7
     groups:
-      maven-updates:
-        patterns:
-          - "*"
+      maven-minor-updates:
+        update-types:
+          - "minor"
+          - "patch"
     registries:
       - maven-central
     ignore:
@@ -51,9 +52,10 @@ updates:
     cooldown:
       default-days: 7
     groups:
-      gradle-updates:
-        patterns:
-          - "*"
+      gradle-minor-updates:
+        update-types:
+          - "minor"
+          - "patch"
     registries:
       - maven-central
     ignore:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -64,9 +64,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    cooldown:
-      default-days: 7
     groups:
-      github-actions-updates:
+      all:
         patterns:
           - "*"


### PR DESCRIPTION
Improve the Dependabot configuration for the Maven and Gradle ecosystems:

- Group only **minor and patch updates**, under the ecosystem-specific names `maven-minor-updates` and `gradle-minor-updates`. This makes Dependabot PR titles indicate which ecosystem is updated, instead of the uninformative "Bump the all group...", and major upgrades arrive as individual PRs that can be reviewed separately (see the Spring Boot 4 bump in #403, which had to be reverted).
- Add a **7-day cooldown**, so releases are only picked up once they are at least a week old.

The `github-actions` ecosystem is intentionally left untouched: it is reworked together with the action pinning changes in #407.