### PR TITLE
Simplify GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -60,7 +60,11 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    groups:
-      all:
-        patterns:
-          - "*"
+    cooldown:
+      default-days: 7
+    # Actions are pinned to major version tags, so only major updates are relevant
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -62,9 +62,10 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
-    # Actions are pinned to major version tags, so only major updates are relevant
+    # `actions/*` are pinned to major version tags, so only major updates are relevant.
+    # Other actions are pinned by hash and receive all updates.
     ignore:
-      - dependency-name: "*"
+      - dependency-name: "actions/*"
         update-types:
           - "version-update:semver-minor"
           - "version-update:semver-patch"

--- a/.github/workflows/graalvm-reusable-test.yaml
+++ b/.github/workflows/graalvm-reusable-test.yaml
@@ -50,14 +50,15 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # 6.0.2
+        uses: actions/checkout@v6
         with:
           repository: 'apache/logging-log4j-samples'
           ref: ${{ inputs.samples-ref }}
 
       - name: Setup GraalVM
-        uses: graalvm/setup-graalvm@60c26726de13f8b90771df4bc1641a52a3159994   # 1.5.2
+        uses: actions/setup-java@v5
         with:
+          distribution: 'graalvm'
           java-version: '21'
 
       - name: Build

--- a/.github/workflows/gradle-reusable-test.yaml
+++ b/.github/workflows/gradle-reusable-test.yaml
@@ -42,6 +42,13 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      ANDROID_API_LEVEL: 31
+      # The default options of `android-emulator-runner`, except:
+      # * `-no-snapshot` is removed, so the AVD snapshot cache can be used,
+      # * `-camera-back none` is added.
+      EMULATOR_OPTIONS: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+
     steps:
 
       - name: Checkout repository
@@ -79,18 +86,18 @@ jobs:
           path: |
             ~/.android/avd
             ~/.android/adb*
-          key: avd-31
+          key: avd-${{ env.ANDROID_API_LEVEL }}
 
       # Only runs on a cache miss to create an AVD snapshot and speed up the next builds
       - name: Generate AVD snapshot
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: ReactiveCircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d   # 2.38.0
         with:
-          api-level: 31
+          api-level: ${{ env.ANDROID_API_LEVEL }}
           # `x86` (the default) is not available for API level 31
           arch: x86_64
           force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          emulator-options: ${{ env.EMULATOR_OPTIONS }}
           disable-animations: false
           script: echo "Generated AVD snapshot"
 
@@ -100,11 +107,11 @@ jobs:
           LOG4J_VERSION: ${{ inputs.log4j-version }}
           LOG4J_REPOSITORY_URL: ${{ inputs.log4j-repository-url }}
         with:
-          api-level: 31
+          api-level: ${{ env.ANDROID_API_LEVEL }}
           # `x86` (the default) is not available for API level 31
           arch: x86_64
           force-avd-creation: false
           # `-no-snapshot-save` loads the cached snapshot, but does not overwrite it
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          emulator-options: -no-snapshot-save ${{ env.EMULATOR_OPTIONS }}
           script: |
             ./gradlew :app:build :app:connectedCheck

--- a/.github/workflows/gradle-reusable-test.yaml
+++ b/.github/workflows/gradle-reusable-test.yaml
@@ -82,5 +82,4 @@ jobs:
           # `x86` (the default) is not available for API level 31
           arch: x86_64
           script: |
-            ./gradlew \
-            :app:build :app:connectedCheck
+            ./gradlew app:build :app:connectedCheck

--- a/.github/workflows/gradle-reusable-test.yaml
+++ b/.github/workflows/gradle-reusable-test.yaml
@@ -72,62 +72,15 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - name: Create AVD Device
-        id: avd
-        shell: bash
-        run: |
-          # Debug environment variables
-          printenv | grep '^ANDROID\|^HOME' | sort
-
-          # Set `ANDROID_USER_HOME` since `emulator` and `avdmanager` use different definitions:
-          # * `avdmanager` uses `$XDG_CONFIG_HOME/.android` with a fallback to `$HOME/.android`:
-          #   https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:common/src/main/java/com/android/prefs/AbstractAndroidLocations.kt
-          # * `emulator` uses `HOME/.android`
-          export ANDROID_USER_HOME="$HOME/.android"
-          echo "ANDROID_USER_HOME=$ANDROID_USER_HOME" >> $GITHUB_ENV
-
-          # List installed and available packages
-          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --list
-          # Download images
-          echo y | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager \
-          --install "system-images;android-31;default;x86_64" \
-          emulator platform-tools
-          # Create device
-          $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager create avd \
-          --name generic-api-31-device \
-          --device "5.4in FWVGA" \
-          --package "system-images;android-31;default;x86_64"
-          $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager list avds
-          # Run emulator
-          $ANDROID_HOME/emulator/emulator \
-          -no-audio -no-window \
-          -avd generic-api-31-device &
-          # Enabled the cleanup job
-          echo EMULATOR_STARTED=true >> $GITHUB_ENV
-          # Wait for device to go online
-          # It might take up to 5 minutes
-          for i in {1..300}; do
-            # Don't stop the script if `adb` fails
-            boot_completed=$($ANDROID_HOME/platform-tools/adb shell getprop sys.boot_completed 2> /dev/null || echo "0")
-            if [ "${boot_completed}" = "1" ]; then break; fi
-            sleep 1
-          done
-
       - name: Test log4j-samples-android
-        shell: bash
+        uses: ReactiveCircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d   # 2.38.0
         env:
           LOG4J_VERSION: ${{ inputs.log4j-version }}
           LOG4J_REPOSITORY_URL: ${{ inputs.log4j-repository-url }}
-        run: |
-          ./gradlew \
-          :app:build :app:connectedCheck
-
-      - name: Remove AVD Device
-        if: ${{ always() && env.EMULATOR_STARTED == 'true' }}
-        shell: bash
-        run: |
-          # Kill the emulator
-          $ANDROID_HOME/platform-tools/adb -s emulator-5554 emu kill
-          # Delete the device
-          $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager delete avd \
-          --name generic-api-31-device
+        with:
+          api-level: 31
+          # `x86` (the default) is not available for API level 31
+          arch: x86_64
+          script: |
+            ./gradlew \
+            :app:build :app:connectedCheck

--- a/.github/workflows/gradle-reusable-test.yaml
+++ b/.github/workflows/gradle-reusable-test.yaml
@@ -82,4 +82,4 @@ jobs:
           # `x86` (the default) is not available for API level 31
           arch: x86_64
           script: |
-            ./gradlew app:build :app:connectedCheck
+            ./gradlew :app:build :app:connectedCheck

--- a/.github/workflows/gradle-reusable-test.yaml
+++ b/.github/workflows/gradle-reusable-test.yaml
@@ -72,6 +72,28 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
+      - name: AVD cache
+        id: avd-cache
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.android/avd
+            ~/.android/adb*
+          key: avd-31
+
+      # Only runs on a cache miss to create an AVD snapshot and speed up the next builds
+      - name: Generate AVD snapshot
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: ReactiveCircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d   # 2.38.0
+        with:
+          api-level: 31
+          # `x86` (the default) is not available for API level 31
+          arch: x86_64
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot"
+
       - name: Test log4j-samples-android
         uses: ReactiveCircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d   # 2.38.0
         env:
@@ -81,5 +103,8 @@ jobs:
           api-level: 31
           # `x86` (the default) is not available for API level 31
           arch: x86_64
+          force-avd-creation: false
+          # `-no-snapshot-save` loads the cached snapshot, but does not overwrite it
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           script: |
             ./gradlew :app:build :app:connectedCheck

--- a/.github/workflows/gradle-reusable-test.yaml
+++ b/.github/workflows/gradle-reusable-test.yaml
@@ -45,24 +45,17 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # 6.0.2
+        uses: actions/checkout@v6
         with:
           repository: 'apache/logging-log4j-samples'
           ref: ${{ inputs.samples-ref }}
 
       - name: Setup Java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654   # 5.2.0
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 17
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e   # 6.1.0
-        with:
-          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
-          develocity-injection-enabled: true
-          develocity-url: https://develocity.apache.org
-          develocity-plugin-version: 3.18.2
+          cache: gradle
 
       - name: Test log4j-samples-gradle-metadata
         shell: bash


### PR DESCRIPTION
This PR reduces the maintenance burden of our GitHub Actions workflows:

- **Pin `actions/*` to major version tags** instead of SHAs. First-party actions are trusted, and major tags remove the need for frequent pin-bump PRs. Dependabot now ignores minor and patch updates for `actions/*` (with a 7-day cooldown), while third-party actions remain pinned by hash and receive all updates.
- **Replace `graalvm/setup-graalvm` with `actions/setup-java`** using the `graalvm` distribution.
- **Replace `gradle/actions/setup-gradle` with the `cache: gradle` option** of `actions/setup-java`. Note: this also removes the Develocity build scan injection.
- **Replace the manual Android emulator setup with `ReactiveCircus/android-emulator-runner`** (now allow-listed in the ASF organization), pinned by hash. This drops about 60 lines of `sdkmanager`/`avdmanager`/`adb` scripting; the action manages the AVD lifecycle, boot waiting, and teardown itself. The `Enable KVM` step is kept, as the action still requires it on GitHub-hosted runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)